### PR TITLE
Measure overall query execution times by operation name

### DIFF
--- a/lib/yabeda/graphql.rb
+++ b/lib/yabeda/graphql.rb
@@ -19,6 +19,11 @@ module Yabeda
                 tags: %i[type field deprecated],
                 buckets: REQUEST_BUCKETS
 
+      histogram :operation_resolve_runtime, comment: "A histogram of operation resolving time",
+                unit: :seconds, per: :operation,
+                tags: %i[operation deprecated],
+                buckets: REQUEST_BUCKETS
+
       counter :fields_request_count, comment: "A counter for specific fields requests",
               tags: %i[type field deprecated]
 

--- a/lib/yabeda/graphql/instrumentation.rb
+++ b/lib/yabeda/graphql/instrumentation.rb
@@ -8,6 +8,10 @@ module Yabeda
       def after_query(query)
         cache(query).each do |_path, options|
           Yabeda.graphql.field_resolve_runtime.measure(options[:tags], options[:duration])
+          Yabeda.graphql.operation_resolve_runtime.measure({
+            operation: query.operation_name,
+            deprecated: options[:tags][:deprecated]
+          }, options[:duration])
           Yabeda.graphql.fields_request_count.increment(options[:tags])
         end
       end

--- a/spec/yabeda/graphql_spec.rb
+++ b/spec/yabeda/graphql_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Yabeda::GraphQL do
   describe "queries" do
     let(:query) do
       <<~GRAPHQL
-        query {
+        query getProductsAndUsers {
           products {
             id title shmitle price { amount currency }
           }
@@ -37,6 +37,15 @@ RSpec.describe Yabeda::GraphQL do
         { type: "Price",   field: "currency", deprecated: false } => kind_of(Numeric),
         { type: "User",    field: "id",       deprecated: false } => kind_of(Numeric),
         { type: "User",    field: "name",     deprecated: false } => kind_of(Numeric),
+      )
+    end
+
+    it "measures operation executions" do
+      Yabeda.graphql.operation_resolve_runtime.sums.clear # This is a hack
+      subject
+      expect(Yabeda.graphql.operation_resolve_runtime.sums).to match(
+        { operation: "getProductsAndUsers", deprecated: false } => kind_of(Numeric),
+        { operation: "getProductsAndUsers", deprecated: true } => kind_of(Numeric),
       )
     end
 


### PR DESCRIPTION
The implementation is probably organized in a bad way, so if I get some feedback, I will adjust it as you please. The overall idea is to have a runtime histogram for queries by [operation name](https://graphql-ruby.org/api-doc/2.0.15/GraphQL/Query#operation_name-instance_method). Of course this only works if the query name is set, but the point here is to see which are the slow queries.