### PR TITLE
Adjust the tracing class name to be compatible with graphql-ruby 2.0

### DIFF
--- a/lib/yabeda/graphql.rb
+++ b/lib/yabeda/graphql.rb
@@ -1,6 +1,6 @@
 require "yabeda"
 require "yabeda/graphql/version"
-require "yabeda/graphql/tracing"
+require "yabeda/graphql/yabeda_tracing"
 require "yabeda/graphql/instrumentation"
 
 module Yabeda
@@ -31,7 +31,7 @@ module Yabeda
 
     def self.use(schema)
       schema.instrument(:query, Instrumentation.new)
-      schema.use Tracing, trace_scalars: true
+      schema.use YabedaTracing, trace_scalars: true
     end
   end
 end

--- a/lib/yabeda/graphql/yabeda_tracing.rb
+++ b/lib/yabeda/graphql/yabeda_tracing.rb
@@ -2,7 +2,7 @@ require "graphql/tracing/platform_tracing"
 
 module Yabeda
   module GraphQL
-    class Tracing < ::GraphQL::Tracing::PlatformTracing
+    class YabedaTracing < ::GraphQL::Tracing::PlatformTracing
 
       self.platform_keys = {
           'lex' => "graphql.lex",


### PR DESCRIPTION
Seems like after [this change](https://github.com/rmosolgo/graphql-ruby/pull/4344) the tracing class needs to have a properly prefixed name:

```ruby
          tracing_name = self.name.split("::").last
          trace_name = tracing_name.sub("Tracing", "Trace")
          if GraphQL::Tracing.const_defined?(trace_name, false)
            trace_module = GraphQL::Tracing.const_get(trace_name)
            schema_defn.trace_with(trace_module, **options)
          else
            tracer = self.new(**options)
            schema_defn.tracer(tracer)
          end
        end
```

There's a workaround to turn on `legacy_tracing`, but currently out-of-the box the yabeda tracing inclusion fails as the new tracing code expects a module if the class name is not in the properly prefixed format. By simply changing the class to `YabedaTracing` the right branch is executed and everything works as it should :wink: 