### PR TITLE
Fall back to legacy_tracing for graphql-ruby 2.0 compatibility

### DIFF
--- a/lib/yabeda/graphql.rb
+++ b/lib/yabeda/graphql.rb
@@ -31,7 +31,7 @@ module Yabeda
 
     def self.use(schema)
       schema.instrument(:query, Instrumentation.new)
-      schema.use Tracing, trace_scalars: true
+      schema.use Tracing, trace_scalars: true, legacy_tracing: true
     end
   end
 end


### PR DESCRIPTION
This is an alternative solution for the problem described in https://github.com/yabeda-rb/yabeda-graphql/pull/5. It is much simpler, but I am afraid that legacy tracing might be dropped from future releases.